### PR TITLE
Fix Google sign-in endpoint usage on /login

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import { GoogleLogo } from '@phosphor-icons/react/dist/ssr'
+import { LoginGoogleButton } from '@/components/login-google-button'
 
 export default async function LoginPage({
   searchParams,
@@ -6,28 +6,13 @@ export default async function LoginPage({
   searchParams?: Promise<{ error?: string }>
 }) {
   const params = await searchParams
-  const hasError = Boolean(params?.error)
 
   return (
     <main className='min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6'>
       <div className='w-full max-w-md rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6 shadow-2xl'>
         <h1 className='text-2xl font-semibold'>Pax Brain Access</h1>
         <p className='mt-2 text-sm text-slate-300'>Sign in with Google to continue.</p>
-
-        {hasError && (
-          <p className='mt-4 rounded-lg border border-red-300/30 bg-red-500/10 px-3 py-2 text-sm text-red-200'>
-            Access denied. This Google account is not authorized for Pax Brain.
-          </p>
-        )}
-
-        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-        <a
-          href='/api/auth/sign-in/social?provider=google&callbackURL=/'
-          className='mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/40 bg-cyan-500/20 py-2 font-medium hover:bg-cyan-500/30'
-        >
-          <GoogleLogo size={18} weight='duotone' />
-          Sign in with Google
-        </a>
+        <LoginGoogleButton hasOAuthError={Boolean(params?.error)} />
       </div>
     </main>
   )

--- a/components/login-google-button.tsx
+++ b/components/login-google-button.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { GoogleLogo } from '@phosphor-icons/react'
+import { useState } from 'react'
+
+export function LoginGoogleButton({ hasOAuthError }: { hasOAuthError: boolean }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onGoogleSignIn = async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/auth/sign-in/social', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'google',
+          callbackURL: '/',
+          disableRedirect: true,
+        }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+
+      if (!res.ok || !data?.url) {
+        throw new Error(data?.message || 'Failed to start Google sign-in')
+      }
+
+      window.location.href = data.url
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      {hasOAuthError && (
+        <p className='mt-4 rounded-lg border border-red-300/30 bg-red-500/10 px-3 py-2 text-sm text-red-200'>
+          Access denied. This Google account is not authorized for Pax Brain.
+        </p>
+      )}
+
+      {error && (
+        <p className='mt-4 rounded-lg border border-red-300/30 bg-red-500/10 px-3 py-2 text-sm text-red-200'>
+          {error}
+        </p>
+      )}
+
+      <button
+        onClick={onGoogleSignIn}
+        disabled={loading}
+        className='mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/40 bg-cyan-500/20 py-2 font-medium hover:bg-cyan-500/30 disabled:opacity-60'
+      >
+        <GoogleLogo size={18} weight='duotone' />
+        {loading ? 'Redirecting…' : 'Sign in with Google'}
+      </button>
+    </>
+  )
+}


### PR DESCRIPTION
Fixes login flow to use POST /api/auth/sign-in/social (with disableRedirect=true) and then redirect browser using returned provider URL.\n\nWhy: direct GET to /api/auth/sign-in/social returns 404 because the endpoint is POST-only.\n\nCloses #5