### PR TITLE
fix: auto-migrate Better Auth tables at startup

### DIFF
--- a/components/login-google-button.tsx
+++ b/components/login-google-button.tsx
@@ -2,6 +2,7 @@
 
 import { GoogleLogo } from '@phosphor-icons/react'
 import { useState } from 'react'
+import { authClient } from '@/lib/auth-client'
 
 export function LoginGoogleButton({ hasOAuthError }: { hasOAuthError: boolean }) {
   const [loading, setLoading] = useState(false)
@@ -11,26 +12,13 @@ export function LoginGoogleButton({ hasOAuthError }: { hasOAuthError: boolean })
     setLoading(true)
     setError(null)
 
-    try {
-      const res = await fetch('/api/auth/sign-in/social', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider: 'google',
-          callbackURL: '/',
-          disableRedirect: true,
-        }),
-      })
+    const { error } = await authClient.signIn.social({
+      provider: 'google',
+      callbackURL: '/',
+    })
 
-      const data = await res.json().catch(() => ({}))
-
-      if (!res.ok || !data?.url) {
-        throw new Error(data?.message || 'Failed to start Google sign-in')
-      }
-
-      window.location.href = data.url
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Sign-in failed')
+    if (error) {
+      setError(error.message || 'Failed to start Google sign-in')
       setLoading(false)
     }
   }

--- a/components/logout-button.tsx
+++ b/components/logout-button.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import { useRouter } from 'next/navigation'
+import { authClient } from '@/lib/auth-client'
 
 export function LogoutButton() {
   const router = useRouter()
 
   const onLogout = async () => {
-    await fetch('/api/auth/sign-out', { method: 'POST' })
+    await authClient.signOut()
     router.push('/login')
     router.refresh()
   }

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from 'better-auth/react'
+
+export const authClient = createAuthClient()

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,18 +1,22 @@
 import { mkdirSync } from 'node:fs'
 import { APIError } from 'better-auth/api'
 import { betterAuth } from 'better-auth'
+import { getMigrations } from 'better-auth/db'
 import Database from 'better-sqlite3'
 
 const ALLOWED_EMAIL = 'digitaldave.eth@gmail.com'
-const DB_DIR = '/app/data'
+const DB_DIR = process.env.NODE_ENV === 'production' ? '/app/data' : './data'
 const DB_PATH = `${DB_DIR}/auth.db`
 
 mkdirSync(DB_DIR, { recursive: true })
 const db = new Database(DB_PATH)
 
-export const auth = betterAuth({
+export const authConfig = {
   database: db,
-  baseURL: process.env.BETTER_AUTH_URL || 'https://brain.onniworks.com',
+  baseURL:
+    process.env.BETTER_AUTH_BASE_URL ||
+    process.env.BETTER_AUTH_URL ||
+    'https://brain.onniworks.com',
   basePath: '/api/auth',
   secret:
     process.env.BETTER_AUTH_SECRET ||
@@ -25,7 +29,7 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-      mapProfileToUser: async (profile) => {
+      mapProfileToUser: async (profile: { email?: string | null }) => {
         if (profile.email?.toLowerCase() !== ALLOWED_EMAIL) {
           throw new APIError('FORBIDDEN', {
             message:
@@ -37,4 +41,24 @@ export const auth = betterAuth({
       },
     },
   },
-})
+} as const
+
+export const auth = betterAuth(authConfig)
+
+async function migrateDatabase() {
+  try {
+    const { toBeCreated, toBeAdded, runMigrations } = await getMigrations(authConfig)
+
+    if (toBeCreated.length > 0 || toBeAdded.length > 0) {
+      console.log(
+        `[Better Auth] Running migrations — tables: ${toBeCreated.length}, fields: ${toBeAdded.length}`,
+      )
+      await runMigrations()
+      console.log('[Better Auth] Migrations complete.')
+    }
+  } catch (err) {
+    console.error('[Better Auth] Migration failed:', err)
+  }
+}
+
+void migrateDatabase()


### PR DESCRIPTION
## Summary
- add programmatic Better Auth migrations via `getMigrations()` in `lib/auth.ts`
- make SQLite path environment-aware (`/app/data` in prod, `./data` locally)
- switch login/logout client actions to Better Auth client helpers via new `lib/auth-client.ts`
- keep auth base URL explicit with `BETTER_AUTH_BASE_URL` / `BETTER_AUTH_URL` fallback

## Validation
- pnpm lint
- pnpm build
- pnpm audit --audit-level high

Closes #7
