### PR TITLE
Make brain dashboard reflect live system files + skills

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -302,7 +302,7 @@ export default async function Home() {
                   <div key={file.path} className='rounded-xl border border-white/10 bg-slate-900/60 p-3'>
                     <div className='mb-2 flex items-center justify-between gap-2'>
                       <div className='font-medium'>{file.name}</div>
-                      <Badge variant={file.exists ? 'secondary' : 'destructive'}>
+                      <Badge variant={file.exists ? 'secondary' : 'muted'} className={!file.exists ? 'border-red-400/40 bg-red-500/20 text-red-200' : ''}>
                         {file.exists ? formatBytes(file.sizeBytes) : 'missing'}
                       </Badge>
                     </div>


### PR DESCRIPTION
## What
- Add a **Brain Files** section that reads core files from `/data/workspace`
- Show per-file path, size, existence state, and a content preview
- Add a **Skills** section that discovers skill directories from:
  - runtime: `/opt/openclaw/app/skills`
  - workspace: `/data/workspace/pax-brain/.agents/skills`

## Why
Improve `brain.onniworks.com` so it better reflects the files and skill surface that make up Pax's operating context.

## Notes
- Lint passed
- Local builds on this host can be killed due to memory constraints

Closes #10